### PR TITLE
fix sexp selection with point just after end-pair

### DIFF
--- a/expand-region.el
+++ b/expand-region.el
@@ -104,6 +104,9 @@
 (defvar er--pushed-mark-p nil
   "t when mark has been pushed for this command.")
 
+(defvar er--pushed-mark-p nil
+  "t when mark has been pushed for this command.")
+
 ;; history is always local to a single buffer
 (make-variable-buffer-local 'er/history)
 


### PR DESCRIPTION
e.g.

```
(let (foo)|
  (messsage "foo"))
```
