### PR TITLE
added js3-mode hook for js expansions

### DIFF
--- a/js-mode-expansions.el
+++ b/js-mode-expansions.el
@@ -165,6 +165,7 @@ If point is inside the value, that will be marked first anyway."
                                                     er/mark-js-outer-return))))
 
 (add-hook 'js2-mode-hook 'er/add-js-mode-expansions)
+(add-hook 'js3-mode-hook 'er/add-js-mode-expansions)
 
 (provide 'js-mode-expansions)
 


### PR DESCRIPTION
really small thing, js3 is basically js2 with some of the indentation stuff from the new js-mode in emacs 24. https://github.com/thomblake/js3-mode 
