### PR TITLE
Add basic erlang-mode expansions

### DIFF
--- a/erlang-mode-expansions.el
+++ b/erlang-mode-expansions.el
@@ -1,0 +1,45 @@
+;;; erlang-mode-expansions.el --- Erlang-specific expansions for expand-region
+
+;; Copyright (C) 2012 Gleb Peregud
+
+;; Author: Gleb Peregud
+;; Based on python-mode-expansions by: Ivan Andrus <darthandrus@gmail.com>
+;; Keywords: marking region erlang
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Feel free to contribute any other expansions for Erlang at
+;;
+;;     https://github.com/magnars/expand-region.el
+
+;;; Bugs:
+
+;; Doesn't handle many Erlang syntax constructs, just the basics
+
+;;; Code:
+
+(defun er/add-erlang-mode-expansions ()
+  "Adds Erlang-specific expansions for buffers in erlang-mode"
+  (set (make-local-variable 'er/try-expand-list) (append
+                                                  er/try-expand-list
+                                                  '(erlang-mark-function
+                                                    erlang-mark-clause))))
+
+(add-hook 'erlang-mode-hook 'er/add-erlang-mode-expansions)
+
+(provide 'erlang-mode-expansions)
+
+;; erlang-mode-expansions.el ends here

--- a/expand-region.el
+++ b/expand-region.el
@@ -474,6 +474,7 @@ before calling `er/expand-region' for the first time."
 (require 'python-mode-expansions)
 (require 'text-mode-expansions)
 (require 'latex-mode-expansions)
+(require 'erlang-mode-expansions)
 (require 'feature-mode-expansions)
 
 (provide 'expand-region)


### PR DESCRIPTION
It adds basic erlang-mode expansions for function clauses and whole functions. Re-uses methods from erlang-mode itself.

P.S. I'd be grateful for updating expand-region at Marmalade if this is merged
