### PR TITLE
Replace "org-mode" with "org" in eval-after-load.

### DIFF
--- a/expand-region.el
+++ b/expand-region.el
@@ -156,7 +156,7 @@
                                      (require 'python-el-fgallina-expansions))))
 (eval-after-load "python-mode"  '(require 'python-mode-expansions))
 (eval-after-load "ruby-mode"    '(require 'ruby-mode-expansions))
-(eval-after-load "org-mode"     '(require 'org-mode-expansions))
+(eval-after-load "org"          '(require 'org-mode-expansions))
 
 ;; unfortunately html-mode inherits from text-mode
 ;; and text-mode-expansions don't work well in html-mode


### PR DESCRIPTION
There is no org-mode.el package, at least in current org-mode
repository, so org-mode-expansions was not loaded automatically.
