### PR TITLE
Issue #42: continue expanding/contracting with one key press

### DIFF
--- a/expand-region-custom.el
+++ b/expand-region-custom.el
@@ -61,6 +61,18 @@ always be copied to the register named after that character."
   :type '(choice (const :tag "Skip whitespace" t)
                  (const :tag "Do not skip whitespace" nil)))
 
+;;;###autoload
+(defcustom expand-region-contract-fast-key "-"
+  "Key to use after an initial expand/contract to contract once more."
+  :group 'expand-region
+  :type 'string)
+
+;;;###autoload
+(defcustom expand-region-reset-fast-key "0"
+  "Key to use after an initial expand/contract to undo."
+  :group 'expand-region
+  :type 'string)
+
 (provide 'expand-region-custom)
 
 ;;; expand-region-custom.el ends here

--- a/expand-region.el
+++ b/expand-region.el
@@ -145,6 +145,10 @@ If prefix argument is negative calls `er/contract-region'.
 If prefix argument is 0 it resets point and mark to their state
 before calling `er/expand-region' for the first time."
   (interactive "p")
+  (er/expand-region-internal arg)
+  (er/prepare-for-more-expansions))
+
+(defun er/expand-region-internal (arg)
   (if (< arg 1)
       (er/contract-region (- arg))
     (er--prepare-expanding)

--- a/features/expand-region.feature
+++ b/features/expand-region.feature
@@ -233,6 +233,48 @@ Feature: Expand Region
     And I press "C-@"
     Then the region should be "(is some)"
 
+  Scenario: Allow pressing the last key of the sequence continuously
+    Given there is no region selected
+    When I insert "This (is (some)) text"
+    And I go to point "12"
+    And I press "C-@"
+    Then the region should be "some"
+    And I press "@"
+    Then the region should be "(some)"
+    And I press "@"
+    Then the region should be "is (some)"
+    And I press "@"
+    Then the region should be "(is (some))"
+
+  Scenario: Allow pressing `-' to contract region
+    Given there is no region selected
+    When I insert "This (is (some)) text"
+    And I go to point "12"
+    And I press "C-@"
+    Then the region should be "some"
+    And I press "@"
+    Then the region should be "(some)"
+    And I press "@"
+    Then the region should be "is (some)"
+    And I press "-"
+    Then the region should be "(some)"
+    And I press "-"
+    Then the region should be "some"
+
+  Scenario: Allow pressing `0' to reset region
+    Given there is no region selected
+    When I insert "This (is (some)) text"
+    And I go to point "12"
+    And I press "C-@"
+    Then the region should be "some"
+    And I press "@"
+    Then the region should be "(some)"
+    And I press "@"
+    Then the region should be "is (some)"
+    And I press "0"
+    Then there is no region selected
+    And cursor should be at point "12"
+
   Scenario: Autocopy-register
     Given there is no region selected
     And autocopy-register is "e"


### PR DESCRIPTION
Single commit to fix issue #42 and #52.

Use two new customizable variables for bindings of contract and reset.
The binding of expand is always the last key of the `er/expand-region'
binding.

Signed-off-by: Damien Cassou damien.cassou@gmail.com
