### PR TITLE
Enable text-mode expansions by default except in some modes

### DIFF
--- a/expand-region-custom.el
+++ b/expand-region-custom.el
@@ -85,6 +85,13 @@ always be copied to the register named after that character."
   :group 'expand-region
   :type 'string)
 
+;;;###autoload
+(defcustom expand-region-exclude-text-mode-expansions
+  '(html-mode nxml-mode)
+  "List of modes which derive from `text-mode' for which text mode expansions are not appropriate."
+  :group 'expand-region
+  :type '(repeat (symbol :tag "Major Mode" unknown)))
+
 (provide 'expand-region-custom)
 
 ;;; expand-region-custom.el ends here

--- a/expand-region.el
+++ b/expand-region.el
@@ -183,12 +183,7 @@ before calling `er/expand-region' for the first time."
   (require 'js-mode-expansions)
   (er/add-js-mode-expansions))
 
-;; unfortunately html-mode inherits from text-mode
-;; and text-mode-expansions don't work well in html-mode
-;; so if you want text-mode-expansions, add this to your
-;; own init:
-;;
-;; (eval-after-load "text-mode"    '(require 'text-mode-expansions))
+(eval-after-load "text-mode"    '(require 'text-mode-expansions))
 
 (provide 'expand-region)
 

--- a/features/html-mode-expansions.feature
+++ b/features/html-mode-expansions.feature
@@ -84,3 +84,12 @@ Feature: html-mode expansions
     And I press "C-@"
     And I press "C-@"
     Then the region should be "<div class='hi'><div>before <span></span></div> after</div>"
+
+  Scenario: Text mode expansions shouldn't be here
+    Given I turn on html-mode
+    And there is no region selected
+    When I insert "Sentence the first.  Sentence the second"
+    And I place the cursor between "first.  " and "Sentence"
+    And I press "C-@"
+    And I press "C-@"
+    Then the region should be "Sentence the first.  Sentence the second"

--- a/features/step-definitions/expand-region-steps.el
+++ b/features/step-definitions/expand-region-steps.el
@@ -76,3 +76,7 @@
               (message "Can not go to character '%s' since it does not exist in the current buffer: %s"))
           (assert search nil message word (espuds-buffer-contents))
           (if (string-equal "front" pos) (backward-word)))))
+
+(When "^I set \\(.+\\) to \\(.+\\)$"
+      (lambda (var val)
+        (set (intern var) (read val))))

--- a/features/text-mode-expansions.feature
+++ b/features/text-mode-expansions.feature
@@ -1,0 +1,112 @@
+Feature: Text-mode expansions
+  Background:
+    Given there is no region selected
+    And I turn on text-mode
+    And I insert:
+    """
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Here is a sentence.  Here is another.  And one with Dr. Baker.
+
+    Another paragraph.  With 2 sentences.
+    
+    "We're on a different page," said the man.
+    """
+
+  Scenario: Mark sentence ending on a line
+    When I place the cursor after "consectetur"
+    And I press "C-@"
+    Then the region should be "consectetur"
+    And I press "C-@"
+    Then the region should be "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    And I press "C-@"
+    Then the region should be:
+    """
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Here is a sentence.  Here is another.  And one with Dr. Baker.
+
+    """
+
+  Scenario: Mark sentence ending on a line 2
+    When I place the cursor before "Lorem"
+    And I press "C-@"
+    Then the region should be "Lorem"
+    And I press "C-@"
+    Then the region should be "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    And I press "C-@"
+    Then the region should be:
+    """
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Here is a sentence.  Here is another.  And one with Dr. Baker.
+
+    """
+
+  Scenario: Mark sentence beginning a line
+    When I place the cursor after "sentence."
+    And I press "C-@"
+    Then the region should be "sentence."
+    And I press "C-@"
+    Then the region should be "Here is a sentence."
+    And I press "C-@"
+    Then the region should be:
+    """
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Here is a sentence.  Here is another.  And one with Dr. Baker.
+
+    """
+
+  Scenario: Mark sentence in the middle of a line
+    When I place the cursor before "is another"
+    And I press "C-@"
+    Then the region should be "is"
+    And I press "C-@"
+    Then the region should be "Here is another."
+    And I press "C-@"
+    Then the region should be:
+    """
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Here is a sentence.  Here is another.  And one with Dr. Baker.
+
+    """
+
+  Scenario: Mark sentence in the middle of a line
+    When I place the cursor after "Baker."
+    And I press "C-@"
+    Then the region should be "Baker."
+    And I press "C-@"
+    Then the region should be "And one with Dr. Baker."
+    And I press "C-@"
+    Then the region should be:
+    """
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Here is a sentence.  Here is another.  And one with Dr. Baker.
+
+    """
+
+  Scenario: Mark a page
+    When I place the cursor after "Baker."
+    And I press "C-u 4 C-@ C-x C-x C-u 2 C-b"
+    Then the region should be:
+    """
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    Here is a sentence.  Here is another.  And one with Dr. Baker.
+
+    Another paragraph.  With 2 sentences.
+
+
+    """
+    # trailing blank lines aren't captured for some reason.  That's
+    # why all the C-x ... C-b stuff
+
+  Scenario: Sentence endings
+    When I place the cursor before "Dr."
+    And I set sentence-end-double-space to nil
+    And I press "C-u 3 C-@"
+    Then the region should be "And one with Dr."
+
+  Scenario: Sentence endings 2
+    When I place the cursor before "Dr."
+    And I set sentence-end-double-space to t
+    And I press "C-u 3 C-@"
+    Then the region should be "And one with Dr. Baker."
+    # I turned sentence-end-double-space back to the default here in
+    # case it comes into play in other tests.

--- a/text-mode-expansions.el
+++ b/text-mode-expansions.el
@@ -36,10 +36,9 @@
   ;; (backward-sentence 1) (mark-end-of-sentence 1)
   ;; doesn't work here because it's repeated and the selection keeps
   ;; growing by sentences, which isn't what's wanted.
-  (backward-sentence 1)
-  (set-mark (point))
   (forward-sentence 1)
-  (exchange-point-and-mark))
+  (set-mark (point))
+  (backward-sentence 1))
 
 (defun er/mark-text-paragraph ()
   "Marks one paragraph."
@@ -48,12 +47,16 @@
   (skip-chars-forward er--space-str))
 
 (defun er/add-text-mode-expansions ()
-  "Adds expansions for buffers in text-mode"
-  (set (make-local-variable 'er/try-expand-list) (append
-                                                  er/try-expand-list
-                                                  '(er/mark-text-sentence
-                                                    er/mark-text-paragraph
-                                                    mark-page))))
+  "Adds expansions for buffers in `text-mode' except for `html-mode'.
+Unfortunately `html-mode' inherits from `text-mode' and
+text-mode-expansions don't work well in `html-mode'."
+  (unless (some #'derived-mode-p expand-region-exclude-text-mode-expansions)
+    (set (make-local-variable 'er/try-expand-list)
+         (append
+          er/try-expand-list
+          '(er/mark-text-sentence
+            er/mark-text-paragraph
+            mark-page)))))
 
 (add-hook 'text-mode-hook 'er/add-text-mode-expansions)
 


### PR DESCRIPTION
It seems that not enabling text-mode expansions because of html-mode is unfortunate.  Instead I have changed `er/add-text-mode-expansions` to not include expansions in html-mode and nxml-mode (using a defcustom).  After searching the emacs sources for text-mode these were the only modes that I thought would be problematic, but there are probably other add on modes that could be added.
