### PR TITLE
Remove advice for js-mode

### DIFF
--- a/expand-region.el
+++ b/expand-region.el
@@ -163,6 +163,7 @@ before calling `er/expand-region' for the first time."
 (eval-after-load "sgml-mode"    '(require 'html-mode-expansions)) ;; html-mode is defined in sgml-mode.el
 (eval-after-load "rhtml-mode"   '(require 'html-mode-expansions))
 (eval-after-load "nxhtml-mode"  '(require 'html-mode-expansions))
+(eval-after-load "js"           '(require 'js-mode-expansions))
 (eval-after-load "js2-mode"     '(require 'js-mode-expansions))
 (eval-after-load "js2-mode"     '(require 'js2-mode-expansions))
 (eval-after-load "js3-mode"     '(require 'js-mode-expansions))
@@ -178,11 +179,6 @@ before calling `er/expand-region' for the first time."
 (eval-after-load "ruby-mode"    '(require 'ruby-mode-expansions))
 (eval-after-load "org"          '(require 'org-mode-expansions))
 (eval-after-load "cc-mode"      '(require 'cc-mode-expansions))
-
-(defadvice javascript-mode (after enable-expand-region activate)
-  (require 'js-mode-expansions)
-  (er/add-js-mode-expansions))
-
 (eval-after-load "text-mode"    '(require 'text-mode-expansions))
 
 (provide 'expand-region)

--- a/js-mode-expansions.el
+++ b/js-mode-expansions.el
@@ -20,16 +20,6 @@
 
 ;;; Commentary:
 
-;; Normal javascript-mode does not have a javascript-mode-hook, which is one of
-;; the reasons I switched to js2-mode. If you want to use this with
-;; javascript-mode, try putting this in your init:
-
-;;     (add-hook 'find-file-hook
-;;               (lambda ()
-;;                 (when (string-match-p "\\.js$" (buffer-file-name))
-;;                   (require 'js-mode-expansions)
-;;                   (er/add-js-mode-expansions))))
-
 ;; Extra expansions for JavaScript that I've found useful so far:
 ;;
 ;;    er/mark-js-function
@@ -170,6 +160,7 @@ If point is inside the value, that will be marked first anyway."
                                                     er/mark-js-inner-return
                                                     er/mark-js-outer-return))))
 
+(add-hook 'js-mode-hook  'er/add-js-mode-expansions)
 (add-hook 'js2-mode-hook 'er/add-js-mode-expansions)
 (add-hook 'js3-mode-hook 'er/add-js-mode-expansions)
 


### PR DESCRIPTION
I don't use javascript, so I may be totally wrong on all this.  I noticed the defadvice and thought it was weird that there wouldn't be a hook.  In bzr emacs, and in Emacs 24.1, `javascript-mode` is an alias to `js-mode` which has a hook `js-mode-hook`.  I checked in Emacs 23.1, but it doesn't have `javascript-mode` nor `js-mode`.  [Emacswiki](http://emacswiki.org/emacs/JavaScriptMode) says it was added in 23.2 which I don't have installed.  Anyway, if early versions of `javascript-mode` doesn't have `js-mode-hook` feel free to reject this pull request, otherwise I think it would be better to not have advice before it gets into Emacs.

P.S. It seems there are as many javascript modes as python modes. :-)
