### PR TITLE
Update run-tests.sh

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -e
-ECUKES=$(find elpa/ecukes-*/ecukes | tail -1)
+ECUKES=$(find elpa/ecukes-* -name "ecukes" | tail -1)
 carton exec "$ECUKES" "$@"


### PR DESCRIPTION
The old version used the deprecated ecukes binary in
elpa/ecukes-*/ecukes.

The new one is in
elpa/ecukes-*/bin/ecukes

The new method finds both and selects the non-deprecated one.
