### PR TITLE
Initialize packages in support

### DIFF
--- a/features/support/env.el
+++ b/features/support/env.el
@@ -8,6 +8,7 @@
 (require 'expand-region)
 (require 'espuds)
 (require 'ert)
+(package-initialize)
 
 (Before
  (global-set-key (kbd "C-@") 'er/expand-region)


### PR DESCRIPTION
add `(package-initialize)` to `support/env.el`. This allows it to use
third party add-ons like e.g. `haskell-mode` to be activated during
tests if it is added as a dependency in the Carton file
