### PR TITLE
Fix er/c-mark-fully-qualified-name so that it can captures identifiers composed of multiple '->'-separated parts.

### DIFF
--- a/cc-mode-expansions.el
+++ b/cc-mode-expansions.el
@@ -95,17 +95,17 @@ either fully inside or fully outside the statement."
   "Mark the current C++ fully qualified identifier.
 
 This function captures identifiers composed of multiple
-'::'-separated parts."
+'::'-separated parts or '->'-separated parts."
   (interactive)
   (er/mark-symbol)
   (when (use-region-p)
     (when (> (point) (mark))
       (exchange-point-and-mark))
-    (while (er/looking-back-exact "::")
+    (while (er/looking-back-max "\\(::\\|->\\)" 2)
       (backward-char 2)
       (skip-syntax-backward "_w"))
     (exchange-point-and-mark)
-    (while (looking-at "::")
+    (while (looking-at "\\(::\\|->\\)")
       (forward-char 2)
       (skip-syntax-forward "_w"))
     (exchange-point-and-mark)))


### PR DESCRIPTION
I'm making this a pull request so '->' is handled like '::' on c-mode.  I hope it's correct and good for merge.
