### PR TITLE
[latex-mode] Fix integration with auctex

### DIFF
--- a/latex-mode-expansions.el
+++ b/latex-mode-expansions.el
@@ -89,6 +89,7 @@ Skips past [] and {} arguments to the environment."
           er/mark-LaTeX-math))))
 
 (er/enable-mode-expansions 'LaTeX-mode 'er/add-latex-mode-expansions)
+(er/enable-mode-expansions 'latex-mode 'er/add-latex-mode-expansions)
 
 (provide 'latex-mode-expansions)
 


### PR DESCRIPTION
Auctex sets major mode to `latex-mode` not `LaTeX-mode`. The old code therefore didn't properly add custom expansions to auctex.
