### PR TITLE
Fix latex-mode expansions setup bug

### DIFF
--- a/latex-mode-expansions.el
+++ b/latex-mode-expansions.el
@@ -88,7 +88,9 @@ Skips past [] and {} arguments to the environment."
           er/mark-LaTeX-inside-environment
           er/mark-LaTeX-math))))
 
-(er/enable-mode-expansions 'LaTeX-mode 'er/add-latex-mode-expansions)
+(let ((latex-mode-hook LaTeX-mode-hook))
+  (er/enable-mode-expansions 'latex-mode 'er/add-latex-mode-expansions)
+  (setq LaTeX-mode-hook latex-mode-hook))
 
 (provide 'latex-mode-expansions)
 


### PR DESCRIPTION
The hook for latex-mode is LaTeX-mode-hook and the major mode for it is
latex-mode. So the function `er/enable-mode-expansions' that assumes
that the former can be inferred from the latter fails. A solution is to
temporarily bind`latex-mode-hook' to `Latex-mode-hook' and save any
modification after the call.
