### PR TITLE
fixed a problem with org-mode: when an org file has bable src code block...

### DIFF
--- a/expand-region-core.el
+++ b/expand-region-core.el
@@ -99,6 +99,7 @@ moving point or mark as little as possible."
               (message "%S" (car try-list))))))
       (setq try-list (cdr try-list)))
 
+    (setq deactivate-mark nil)
     (goto-char best-start)
     (set-mark best-end)
 


### PR DESCRIPTION
...s, the mark was deactivated somewhere along the line.
