### PR TITLE
fix byte compile warning for clojure-mode-expansions

### DIFF
--- a/clojure-mode-expansions.el
+++ b/clojure-mode-expansions.el
@@ -33,6 +33,7 @@
 ;;; Code:
 
 (require 'expand-region-core)
+(require 'er-basic-expansions)
 
 (defun er/mark-clj-word ()
   "Mark the entire word around or in front of point, including dashes."


### PR DESCRIPTION
This change should remove this byte compilation warning:

clojure-mode-expansions.el:106:1:Warning: the function
    `er--move-point-forward-out-of-string' is not known to be defined.
