### PR TITLE
fix byte compile warning for cc-mode-expansions

### DIFF
--- a/cc-mode-expansions.el
+++ b/cc-mode-expansions.el
@@ -46,6 +46,7 @@
 ;;; Code:
 
 (require 'expand-region-core)
+(require 'cc-cmds)
 
 (defun er/c-mark-statement ()
   "Mark the current C statement.


### PR DESCRIPTION
fixes at least some of these warnings:

cc-mode-expansions.el:185:1:Warning: the following functions are not known to
    be defined: c-end-of-statement, er/mark-outside-pairs,
    c-beginning-of-statement, er/mark-symbol
