### PR TITLE
py-goto-beyond-clause not known, use py-end-of-clause-bol

### DIFF
--- a/python-mode-expansions.el
+++ b/python-mode-expansions.el
@@ -43,6 +43,8 @@
 
 (defvar er--python-string-delimiter "'\"")
 
+(defalias 'py-goto-beyond-clause 'py-end-of-clause-bol)
+
 (defun er/mark-outside-python-string ()
   "Marks region outside a (possibly multi-line) Python string"
   (interactive)
@@ -104,10 +106,10 @@ line and selecting the surrounding block."
         (while (> (current-column) start-col)
           (forward-line -1) (back-to-indentation)))
       (set-mark (point))
-      (py-goto-beyond-clause) (forward-line) (back-to-indentation)
+      (py-end-of-clause-bol) (forward-line) (back-to-indentation)
       (while (and (looking-at secondary-re)
                   (>= (current-column) start-col))
-        (py-goto-beyond-clause) (forward-line) (back-to-indentation))
+        (py-end-of-clause-bol) (forward-line) (back-to-indentation))
       (forward-line -1) (end-of-line)
       (exchange-point-and-mark))))
 


### PR DESCRIPTION
Handling of clauses is a rather recent feature of python-mode.el

py-goto-beyond-block existed, however clause seems right here 
