### PR TITLE
added er/org-mark-parent-element

### DIFF
--- a/features/org-mode-expansions.feature
+++ b/features/org-mode-expansions.feature
@@ -53,3 +53,152 @@ Feature: org-mode expansions
     ** lvl 2
     *** lvl 3
     """
+  Scenario: Org list item
+    Given I turn on org-mode
+    When I insert:
+    """
+    * lvl 1
+    ** lvl 2
+    - list item one
+    - list item two
+    #+BEGIN_SRC html
+    <div class="myclass">Some text</div>
+    #+END_SRC
+
+    This is a sentence.  And a second one makes a paragraph.
+
+    *** lvl 3
+    """
+    And I place the cursor before "item one"
+    And I press "C-@"
+    And I press "C-@"
+    Then the region should be:
+    """
+    list item one
+
+    """
+
+  Scenario: Org list element
+    Given I turn on org-mode
+    When I insert:
+    """
+    * lvl 1
+    ** lvl 2
+
+    - list item one
+    - list item two
+
+    #+BEGIN_SRC html
+    <div class="myclass">Some text</div>
+    #+END_SRC
+
+    This is a sentence.  And a second one makes a paragraph.
+
+    *** lvl 3
+    """
+    And I place the cursor before "item one"
+    And I press "C-@"
+    And I press "C-@"
+    And I press "C-@"
+    Then the region should be:
+    """
+    - list item one
+
+    """
+
+  Scenario: Org entire list
+    Given I turn on org-mode
+    When I insert:
+    """
+    * lvl 1
+    ** lvl 2
+
+    - list item one
+    - list item two
+
+    #+BEGIN_SRC html
+    <div class="myclass">Some text</div>
+    #+END_SRC
+
+    This is a sentence.  And a second one makes a paragraph.
+
+    *** lvl 3
+    """
+    And I place the cursor before "item one"
+    And I press "C-@"
+    And I press "C-@"
+    And I press "C-@"
+    And I press "C-@"
+    Then the region should be:
+    """
+    - list item one
+    - list item two
+    """
+
+  Scenario: Org from list to subheading
+    Given I turn on org-mode
+    When I insert:
+    """
+    * lvl 1
+    ** lvl 2
+    - list item one
+    - list item two
+
+    #+BEGIN_SRC html
+    <div class="myclass">Some text</div>
+    #+END_SRC
+
+    This is a sentence.  And a second one makes a paragraph.
+
+    *** lvl 3
+    """
+    And I place the cursor before "item one"
+    And I press "C-@"
+    And I press "C-@"
+    And I press "C-@"
+    And I press "C-@"
+    And I press "C-@"
+    And I press "C-@"
+    And I press "C-@"
+    Then the region should be:
+    """
+    ** lvl 2
+    - list item one
+    - list item two
+
+    #+BEGIN_SRC html
+    <div class="myclass">Some text</div>
+    #+END_SRC
+
+    This is a sentence.  And a second one makes a paragraph.
+
+    *** lvl 3
+    """
+
+  Scenario: Org code block
+    Given I turn on org-mode
+    When I insert:
+    """
+    * lvl 1
+    ** lvl 2
+
+    - list item one
+    - list item two
+
+    #+BEGIN_SRC html
+    <div class="myclass"> Some text </div>
+    #+END_SRC
+
+    This is a sentence.  And a second one makes a paragraph.
+
+    *** lvl 3
+    """
+    And I place the cursor between "Some " and "text"
+    And I press "C-@"
+    And I press "C-@"
+    Then the region should be:
+    """
+    #+BEGIN_SRC html
+    <div class="myclass"> Some text </div>
+    #+END_SRC
+    """

--- a/the-org-mode-expansions.el
+++ b/the-org-mode-expansions.el
@@ -56,27 +56,51 @@
   (interactive)
   (let ((case-fold-search t)
         (re "#\\+begin_\\(\\sw+\\)"))
-    (unless (looking-at re)
-      (search-backward-regexp re))
+    (unless (looking-at re)      (search-backward-regexp re))
     (set-mark (point))
     (search-forward (concat "#+end_" (match-string 1)))
     (exchange-point-and-mark)))
 
-(defun er/mark-org-parent ()
+(defun er/mark-org-parent-tree ()
   "Marks a heading 1 level up from current subheading"
   (interactive)
   (org-up-element)
   (org-mark-subtree))
 
-(defun er/add-org-mode-expansions ()
-  "Adds org-specific expansions for buffers in org-mode"
-  (set (make-local-variable 'er/try-expand-list) (append
-                                                  er/try-expand-list
-                                                  '(org-mark-subtree
-                                                    er/mark-org-code-block
-                                                    er/mark-sentence
-                                                    er/mark-org-parent
-                                                    er/mark-paragraph))))
+(defun er/mark-org-parent-element ()
+  "Marks an org parent element"
+  (interactive)
+  (let ((parent (plist-get (car (cdr (org-element-at-point))) :parent)))
+    (let ((parent-props (car (cdr parent))))
+      (if (plist-get parent-props :begin)
+          (progn
+            (set-mark (plist-get parent-props :begin))
+            (goto-char (plist-get parent-props :end))
+            (exchange-point-and-mark)
+            )))
+    )
+)
+
+(defun mwp-test-mark ()
+  (interactive)
+  (let ((testme 1426))
+    (goto-char testme)
+    (set-mark (point))
+    (goto-char 1525)
+    (exchange-point-and-mark)
+  ))
+
+  (defun er/add-org-mode-expansions ()
+    "Adds org-specific expansions for buffers in org-mode"
+    (set (make-local-variable 'er/try-expand-list) (append
+                                                    er/try-expand-list
+                                                    '(org-mark-subtree
+                                                      org-mark-element
+                                                      er/mark-org-code-block
+                                                      er/mark-sentence
+                                                      er/mark-org-parent-tree
+                                                      er/mark-org-parent-element
+                                                      er/mark-paragraph))))
 
 (er/enable-mode-expansions 'org-mode 'er/add-org-mode-expansions)
 


### PR DESCRIPTION
This adds one more function to the org-mode expansions -- "er/org-mark-parent-element" -- which increases specificity when working with lists especially.  When a word in a list item is expanded, expansion goes:

word --> paragraph --> list item --> list --> subheading --> parent --> parent... --> file

also wrote some new tests which I _think_ work. The tests seem to require more C-@'s than does actual use.  
