### PR TITLE
remove set-mark-default-inactive, which is obsoleted

### DIFF
--- a/expand-region-core.el
+++ b/expand-region-core.el
@@ -70,8 +70,7 @@ moving point or mark as little as possible."
          (end (max p1 p2))
          (try-list er/try-expand-list)
          (best-start (point-min))
-         (best-end (point-max))
-         (set-mark-default-inactive nil))
+         (best-end (point-max)))
 
     ;; add hook to clear history on buffer changes
     (unless er/history

--- a/features/step-definitions/expand-region-steps.el
+++ b/features/step-definitions/expand-region-steps.el
@@ -1,6 +1,6 @@
 (Given "^mark is inactive by default$"
        (lambda ()
-         (setq set-mark-default-inactive t)))
+         (transient-mark-mode 0)))
 
 (When "^I expand the region$"
       (lambda ()

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -19,7 +19,6 @@
  (transient-mark-mode 1)
  (cua-mode 0)
  (setq er--show-expansion-message t)
- (setq set-mark-default-inactive nil)
  (deactivate-mark))
 
 (After)


### PR DESCRIPTION
I am slightly worried about removing `set-mark-default-inactive` from the `let` in `er--expand-region-1`, but the tests pass.  After applying this to master, there are no byte compilation warnings!
