### PR TITLE
disable byte compiling for test helper files

### DIFF
--- a/features/step-definitions/expand-region-steps.el
+++ b/features/step-definitions/expand-region-steps.el
@@ -80,3 +80,6 @@
 (When "^I set \\(.+\\) to \\(.+\\)$"
       (lambda (var val)
         (set (intern var) (read val))))
+;; Local Variables:
+;; no-byte-compile: t
+;; End:

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -23,3 +23,6 @@
  (deactivate-mark))
 
 (After)
+;; Local Variables:
+;; no-byte-compile: t
+;; End:


### PR DESCRIPTION
I'm not sure if this makes sense to merge in, but I had these Local Variables to disable byte compilation in the test files while I was working on reducing the byte compilation warnings. It might be helpful for development purposes.
