### PR TITLE
Added: test coverage with undercover.el

### DIFF
--- a/Cask
+++ b/Cask
@@ -4,4 +4,5 @@
 
 (development
   (depends-on "ecukes")
-  (depends-on "espuds"))
+  (depends-on "espuds")
+  (depends-on "undercover"))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# expand-region.el [![Build Status](https://secure.travis-ci.org/magnars/expand-region.el.png)](http://travis-ci.org/magnars/expand-region.el)
+# expand-region.el [![Build Status](https://secure.travis-ci.org/magnars/expand-region.el.png)](http://travis-ci.org/magnars/expand-region.el) [![Coverage Status](https://img.shields.io/coveralls/magnars/expand-region.el.svg)](https://coveralls.io/r/magnars/expand-region.el)
 
 Expand region increases the selected region by semantic units. Just keep
 pressing the key until it selects what you want.

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -5,6 +5,9 @@
 
 (add-to-list 'load-path expand-region-root-path)
 
+(require 'undercover)
+(undercover "*.el")
+
 (require 'expand-region)
 (require 'espuds)
 (require 'ert)


### PR DESCRIPTION
Hi!

I'm author of new library [undercover.el](https://github.com/sviridov/undercover.el) that provides a test coverage check for Emacs packages.

This commit adds coverage check for `expand-region.el` package. [See](https://coveralls.io/builds/1337754) my fork coverage results. To enable it, you need to add repository to [Coveralls](https://coveralls.io/).

It will be awesome if you accept this commit! Thanks!
