### PR TITLE
merlin

### DIFF
--- a/expand-region.el
+++ b/expand-region.el
@@ -189,6 +189,7 @@ before calling `er/expand-region' for the first time."
 (eval-after-load "cperl-mode"    '(require 'cperl-mode-expansions))
 (eval-after-load "sml-mode"      '(require 'sml-mode-expansions))
 (eval-after-load "enh-ruby-mode" '(require 'enh-ruby-mode-expansions))
+(eval-after-load "merlin"        '(require 'merlin-mode-expansions))
 
 (provide 'expand-region)
 

--- a/features/merlin-mode-expansions.feature
+++ b/features/merlin-mode-expansions.feature
@@ -1,0 +1,34 @@
+Feature: merlin-mode expansions
+  In order to quickly and precisely mark merlin code blocks
+  As an Emacs user
+  I want to expand to them
+
+  Scenario: Mark name
+    Given I turn on merlin-mode
+    When I insert:
+    """
+    let () =
+      List.iter (fun s ->
+          print_endline s)
+        ["okta"; "guokte"]
+    """
+    And I place the cursor before "print_endline"
+    And I press "C-@"
+    Then the region should be "@print_endline"
+
+  Scenario: Mark fun
+    Given I turn on merlin-mode
+    When I insert:
+    """
+    let () =
+      List.iter (fun s ->
+          print_endline s)
+        ["okta"; "guokte"]
+    """
+    And I place the cursor before "fun "
+    And I press "C-@"
+    Then the region should be:
+    """
+    (fun s ->
+          print_endline s)
+    """

--- a/merlin-mode-expansions.el
+++ b/merlin-mode-expansions.el
@@ -1,0 +1,35 @@
+;;; merlin-mode-expansions.el --- OCaml-specific expansions for expand-region
+
+;; Copyright (C) 2014 Kevin Brubeck Unhammer
+
+;; Author: Kevin Brubeck Unhammer <unhammer@fsfe.org>
+;; Keywords: marking region merlin
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'expand-region-core)
+(require 'merlin)
+
+(defun er/add-merlin-mode-expansions ()
+  "Add merlin-mode expansions"
+  (set (make-local-variable 'er/try-expand-list)
+       '(merlin-enclosing-expand)))
+
+(er/enable-mode-expansions 'merlin-mode 'er/add-merlin-mode-expansions)
+
+(provide 'merlin-mode-expansions)
+
+;; merlin-mode-expansions.el ends here


### PR DESCRIPTION
merlin already provides an expand-region-type function, so I just used that. A bit superfluous maybe, but adding it to expand-region means people who use er everywhere don't have to rebind the key in merlin-mode.

I don't know how to get the tests to run though (presumably I have to depend on merlin somewhere?)
