### PR TITLE
Adding a mark-subword function and including it in expand-region.el

### DIFF
--- a/expand-region.el
+++ b/expand-region.el
@@ -189,6 +189,7 @@ before calling `er/expand-region' for the first time."
 (eval-after-load "cperl-mode"    '(require 'cperl-mode-expansions))
 (eval-after-load "sml-mode"      '(require 'sml-mode-expansions))
 (eval-after-load "enh-ruby-mode" '(require 'enh-ruby-mode-expansions))
+(eval-after-load "subword-mode"  '(require 'subword-mode-expansions))
 
 (provide 'expand-region)
 

--- a/subword-mode-expansions.el
+++ b/subword-mode-expansions.el
@@ -1,0 +1,49 @@
+;;; subword-mode-expansions.el --- Expansions for subword-mode to be used for CamelCase
+
+;; Copyright (C) 2014 Lefteris Karapetsas
+
+;; Author: Lefteris Karapetsas
+;; Keywords: marking region
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Provides extra expansions for subword mode so that when
+;; subword-mode is non-nil different words can be selected in CamelCase.
+;; Feel free to contribute any other expansions:
+;;
+;;     https://github.com/magnars/expand-region.el
+
+;;; Code:
+
+(require 'expand-region-core)
+
+(defun er/mark-subword ()
+  "Mark a subword, a part of a CamelCase identifier."
+  (interactive)
+  (subword-right 1)
+  (set-mark (point))
+  (subword-left 1))
+
+(defun er/add-subword-mode-expansions ()
+  "Add expansions for buffers in `subword-mode'."
+  (set (make-local-variable 'er/try-expand-list)
+       (append er/try-expand-list
+	       '(er/mark-subword))))
+
+(er/enable-mode-expansions 'subword-mode 'er/add-subword-mode-expansions)
+
+(provide 'subword-mode-expansions)
+;;; subword-mode-expansions.el ends here


### PR DESCRIPTION
As you advised from #143 I made a function to mark the subword when `subword-mode` is non-nil and included it in the main expand-region.el expansions.

I ran the tests with cask before the change and afterwards and there was no change. (Currently there are 3 tests failing in my machine but they seem unrelated).

I tested the expansion on a C++ project with subword mode being on and it worked as expected. With `subword-mode` off, it simply selected the whole word as would be the expected behaviour.
