### PR TITLE
Add return value to mark-outside-pair & mark-outside-quotes for customiz...

### DIFF
--- a/er-basic-expansions.el
+++ b/er-basic-expansions.el
@@ -139,19 +139,22 @@ period and marks next symbol."
     (exchange-point-and-mark)))
 
 (defun er/mark-outside-quotes ()
-  "Mark the current string, including the quotation marks."
+  "Mark the current string, including the quotation marks. It will returns t if region expanded."
   (interactive)
-  (if (er--point-inside-string-p)
-      (er--move-point-backward-out-of-string)
-    (when (and (not (use-region-p))
-               (er/looking-back-on-line "\\s\""))
-      (backward-char)
-      (er--move-point-backward-out-of-string)))
-  (when (looking-at "\\s\"")
-    (set-mark (point))
-    (forward-char)
-    (er--move-point-forward-out-of-string)
-    (exchange-point-and-mark)))
+  (let ((before (cons (mark) (point))))
+    (if (er--point-inside-string-p)
+        (er--move-point-backward-out-of-string)
+      (when (and (not (use-region-p))
+                 (er/looking-back-on-line "\\s\""))
+        (backward-char)
+        (er--move-point-backward-out-of-string)))
+    (when (looking-at "\\s\"")
+      (set-mark (point))
+      (forward-char)
+      (er--move-point-forward-out-of-string)
+      (exchange-point-and-mark))
+    (message "%S,%S" before (cons (mark) (point)))
+    (not (equal (cons (mark) (point)) before))))
 
 ;; Pairs - ie [] () {} etc
 
@@ -187,19 +190,21 @@ period and marks next symbol."
              (point)))))
 
 (defun er/mark-outside-pairs ()
-  "Mark pairs (as defined by the mode), including the pair chars."
+  "Mark pairs (as defined by the mode), including the pair chars. It will return t if region expanded."
   (interactive)
-  (if (er/looking-back-on-line "\\s)+\\=")
-      (ignore-errors (backward-list 1))
-    (skip-chars-forward er--space-str))
-  (when (and (er--point-inside-pairs-p)
-             (or (not (er--looking-at-pair))
-                 (er--looking-at-marked-pair)))
-    (goto-char (nth 1 (syntax-ppss))))
-  (when (er--looking-at-pair)
-    (set-mark (point))
-    (forward-list)
-    (exchange-point-and-mark)))
+  (let ((before (cons (mark) (point))))
+    (if (er/looking-back-on-line "\\s)+\\=")
+        (ignore-errors (backward-list 1))
+      (skip-chars-forward er--space-str))
+    (when (and (er--point-inside-pairs-p)
+               (or (not (er--looking-at-pair))
+                   (er--looking-at-marked-pair)))
+      (goto-char (nth 1 (syntax-ppss))))
+    (when (er--looking-at-pair)
+      (set-mark (point))
+      (forward-list)
+      (exchange-point-and-mark))
+    (not (equal (cons (mark) (point)) before))))
 
 (require 'thingatpt)
 


### PR DESCRIPTION
I want to customize er/expand-region behavior using er/mark-outside-quotes & er/mark-outside-pairs. Adding return value to mark-outside-quotes & mark-outside-pairs enables higher customization.
Here is a my command:
```lisp
(defun my/expand-region ()
  (interactive)
  (cl-case (char-syntax (char-after))
    (?\"
     (unless (er/mark-outside-quotes)
       (call-interactively 'er/expand-region)))
    (?\)
     (unless (er/mark-outside-pairs)
       (call-interactively 'er/expand-region)))))
```
Executing command multiple time behave like below.
1. On end of quote
![_scratch_](https://cloud.githubusercontent.com/assets/235329/6982942/093cf916-da53-11e4-803f-da6cf9a6abc3.png)
![_scratch__2](https://cloud.githubusercontent.com/assets/235329/6982958/457abd00-da53-11e4-9ed5-f381bd9a8610.png)
![_scratch__1](https://cloud.githubusercontent.com/assets/235329/6982960/4938491c-da53-11e4-9923-80a96e064405.png)
2. On end of pair
![_scratch__5](https://cloud.githubusercontent.com/assets/235329/6982964/4ed0e938-da53-11e4-83a2-e5dedcbbd46c.png)
![_scratch__4](https://cloud.githubusercontent.com/assets/235329/6982966/528cfbb6-da53-11e4-9265-2a3058057778.png)
![_scratch__3](https://cloud.githubusercontent.com/assets/235329/6982968/55fc86e0-da53-11e4-9b81-1b6c8e7f58cb.png)
How about this proposal?