### PR TITLE
Ensure expand-region can be upgraded without uninstall.

### DIFF
--- a/expand-region-core.el
+++ b/expand-region-core.el
@@ -61,7 +61,7 @@
 
 ;; save-mark-and-excursion in Emacs 25 works like save-excursion did before
 (eval-when-compile
-  (when (not (fboundp 'save-mark-and-excursion))
+  (when (< emacs-major-version 25)
     (defmacro save-mark-and-excursion (&rest body)
       `(save-excursion ,@body))))
 


### PR DESCRIPTION
As discussed in 
https://github.com/magnars/expand-region.el/commit/69819ac1417b8fad6561f8072d76d0fa2fcebfc0 , expand-region can't be byte-compiled in an Emacs 24 instance where `save-mark-and-excursion` is already bound.

I think this is sensible solution, let me know what you think.