### PR TITLE
Bugfix: save-mark-and-excursion does not exist until E25.1

### DIFF
--- a/expand-region-core.el
+++ b/expand-region-core.el
@@ -59,9 +59,11 @@
     (set-register (aref expand-region-autocopy-register 0)
                   (filter-buffer-substring (region-beginning) (region-end)))))
 
-;; save-mark-and-excursion in Emacs 25 works like save-excursion did before
+;; save-mark-and-excursion in Emacs 25.1 and above works like save-excursion did before
 (eval-when-compile
-  (when (< emacs-major-version 25)
+  (when (or
+         (< emacs-major-version 25)
+         (and (= emacs-major-version 25) (< emacs-minor-version 1)))
     (defmacro save-mark-and-excursion (&rest body)
       `(save-excursion ,@body))))
 


### PR DESCRIPTION
Switching to version detection in commit 5c2ad46fde153ba79dd6c3815a7956f73a20c123 broke expand-region on Emacs 25.0.50. According to [this discussion](http://git.savannah.gnu.org/cgit/emacs.git/commit/?id=255a011f0ecf004b31c59945b10154b10fac3af1) the breaking change is in 25.1

Related: #160, #165, 69819ac1417b8fad6561f8072d76d0fa2fcebfc0