### PR TITLE
Revert "Bugfix: save-mark-and-excursion does not exist until E25.1"

### DIFF
--- a/expand-region-core.el
+++ b/expand-region-core.el
@@ -59,11 +59,9 @@
     (set-register (aref expand-region-autocopy-register 0)
                   (filter-buffer-substring (region-beginning) (region-end)))))
 
-;; save-mark-and-excursion in Emacs 25.1 and above works like save-excursion did before
+;; save-mark-and-excursion in Emacs 25 works like save-excursion did before
 (eval-when-compile
-  (when (or
-         (< emacs-major-version 25)
-         (and (= emacs-major-version 25) (< emacs-minor-version 1)))
+  (when (< emacs-major-version 25)
     (defmacro save-mark-and-excursion (&rest body)
       `(save-excursion ,@body))))
 


### PR DESCRIPTION
Reverts magnars/expand-region.el#177