### PR TITLE
flet is obsolete as of 24.3 replaced with cl-flet

### DIFF
--- a/features/step-definitions/expand-region-steps.el
+++ b/features/step-definitions/expand-region-steps.el
@@ -4,17 +4,17 @@
 
 (When "^I expand the region$"
       (lambda ()
-        (flet ((message (&rest args) nil))
+        (cl-flet ((message (&rest args) nil))
           (er/expand-region 1))))
 
 (When "^I quit$"
       (lambda ()
-        (flet ((signal (&rest args) nil))
+        (cl-flet ((signal (&rest args) nil))
           (keyboard-quit))))
 
 (When "^I expand the region \\([0-9]+\\) times$"
       (lambda (arg)
-        (flet ((message (&rest args) nil))
+        (cl-flet ((message (&rest args) nil))
           (er/expand-region (string-to-number arg)))))
 
 (And "^I contract the region$"


### PR DESCRIPTION
`cl-flet` does what `flet` does but does not result in a warning when
running the ecukes.