### PR TITLE
fix #163 - prefer current pair over previous pair

### DIFF
--- a/er-basic-expansions.el
+++ b/er-basic-expansions.el
@@ -189,7 +189,8 @@ period and marks next symbol."
 (defun er/mark-outside-pairs ()
   "Mark pairs (as defined by the mode), including the pair chars."
   (interactive)
-  (if (er/looking-back-on-line "\\s)+\\=")
+  (if (and (er/looking-back-on-line "\\s)+\\=")
+           (not (er--looking-at-pair)))
       (ignore-errors (backward-list 1))
     (skip-chars-forward er--space-str))
   (when (and (er--point-inside-pairs-p)

--- a/features/er-basic-expansions.feature
+++ b/features/er-basic-expansions.feature
@@ -54,3 +54,11 @@ Feature: Basic expansions
     And I press "C-@"
     And I press "C-@"
     Then the region should be "document.write('abc')"
+
+  Scenario: Mark current pair
+    Given I turn on emacs-lisp-mode
+    And I insert "((foo)(bar))"
+    When I place the cursor after "oo)"
+    And I press "C-@"
+    Then the region should be "(bar)"
+


### PR DESCRIPTION
I think this resolved #163 by only moving back when we're not in a valid pair.

I'm having trouble getting `c-mode` and `org-mode` features to run with or without this change though, so I might be missing some test failure.
