### PR TITLE
Test against Emacs 24, 25 and trunk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,17 @@
 language: emacs-lisp
 before_install:
-  - if [ "$EMACS" = 'emacs-snapshot' ]; then
-      sudo add-apt-repository -y ppa:cassou/emacs &&
-      sudo apt-get update -qq &&
-      sudo apt-get install -qq
-          emacs-snapshot-el emacs-snapshot-gtk emacs-snapshot;
-    fi
-  - if [ "$EMACS" = 'emacs24' ]; then
-      sudo add-apt-repository -y ppa:cassou/emacs &&
-      sudo apt-get update -qq &&
-      sudo apt-get install -qq
-          emacs24 emacs24-el emacs24-common-non-dfsg;
-    fi
-  - curl -fsSkL https://raw.github.com/cask/cask/master/go | python
-  - export PATH="/home/travis/.cask/bin:$PATH"
+  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
+  - evm install $EVM_EMACS --use --skip
   - cask
 env:
-  - EMACS=emacs24 TAGS=""
+  - EVM_EMACS=emacs-24.3-travis
+  - EVM_EMACS=emacs-24.4-travis
+  - EVM_EMACS=emacs-24.5-travis
+  - EVM_EMACS=emacs-25.1-travis
+  - EVM_EMACS=emacs-git-snapshot-travis
 script:
   ./run-travis-ci.sh
+
+matrix:
+  allow_failures:
+    - env: EVM_EMACS=emacs-git-snapshot-travis

--- a/the-org-mode-expansions.el
+++ b/the-org-mode-expansions.el
@@ -73,13 +73,14 @@
 
 (defun er/add-org-mode-expansions ()
   "Adds org-specific expansions for buffers in org-mode"
-  (set (make-local-variable 'er/try-expand-list) (append
-                                                  er/try-expand-list
-                                                  '(org-mark-subtree
-                                                    er/mark-org-code-block
-                                                    er/mark-sentence
-                                                    er/mark-org-parent
-                                                    er/mark-paragraph))))
+  (set (make-local-variable 'er/try-expand-list)
+       (append
+        (remove #'er/mark-defun er/try-expand-list)
+        '(org-mark-subtree
+          er/mark-org-code-block
+          er/mark-sentence
+          er/mark-org-parent
+          er/mark-paragraph))))
 
 (er/enable-mode-expansions 'org-mode 'er/add-org-mode-expansions)
 


### PR DESCRIPTION
Tests are currently failing on my local Emacs 25.1 install, so I thought it would make sense to expand the Emacs versions used to test expand-region on Travis.