### PR TITLE
Fix text-mode, c-mode and org-mode on recent Emacsen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,17 @@
 language: emacs-lisp
 before_install:
-  - if [ "$EMACS" = 'emacs-snapshot' ]; then
-      sudo add-apt-repository -y ppa:cassou/emacs &&
-      sudo apt-get update -qq &&
-      sudo apt-get install -qq
-          emacs-snapshot-el emacs-snapshot-gtk emacs-snapshot;
-    fi
-  - if [ "$EMACS" = 'emacs24' ]; then
-      sudo add-apt-repository -y ppa:cassou/emacs &&
-      sudo apt-get update -qq &&
-      sudo apt-get install -qq
-          emacs24 emacs24-el emacs24-common-non-dfsg;
-    fi
-  - curl -fsSkL https://raw.github.com/cask/cask/master/go | python
-  - export PATH="/home/travis/.cask/bin:$PATH"
+  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
+  - evm install $EVM_EMACS --use --skip
   - cask
 env:
-  - EMACS=emacs24 TAGS=""
+  - EVM_EMACS=emacs-24.3-travis
+  - EVM_EMACS=emacs-24.4-travis
+  - EVM_EMACS=emacs-24.5-travis
+  - EVM_EMACS=emacs-25.1-travis
+  - EVM_EMACS=emacs-git-snapshot-travis
 script:
   ./run-travis-ci.sh
+
+matrix:
+  allow_failures:
+    - env: EVM_EMACS=emacs-git-snapshot-travis

--- a/cc-mode-expansions.el
+++ b/cc-mode-expansions.el
@@ -71,7 +71,7 @@ either fully inside or fully outside the statement."
 
   (let (beg end)
     ;; Determine boundaries of the outside-pairs region
-    (save-excursion
+    (save-mark-and-excursion
       (c-end-of-statement)
       (er/mark-outside-pairs)
       (setq beg (point)

--- a/expand-region.el
+++ b/expand-region.el
@@ -185,7 +185,7 @@ before calling `er/expand-region' for the first time."
 (eval-after-load 'ruby-mode      '(require 'ruby-mode-expansions))
 (eval-after-load 'org            '(require 'the-org-mode-expansions))
 (eval-after-load 'cc-mode        '(require 'cc-mode-expansions))
-(eval-after-load 'text-mode      '(require 'text-mode-expansions))
+(eval-after-load "text-mode"      '(require 'text-mode-expansions))
 (eval-after-load 'cperl-mode     '(require 'cperl-mode-expansions))
 (eval-after-load 'sml-mode       '(require 'sml-mode-expansions))
 (eval-after-load 'enh-ruby-mode  '(require 'enh-ruby-mode-expansions))

--- a/the-org-mode-expansions.el
+++ b/the-org-mode-expansions.el
@@ -73,13 +73,14 @@
 
 (defun er/add-org-mode-expansions ()
   "Adds org-specific expansions for buffers in org-mode"
-  (set (make-local-variable 'er/try-expand-list) (append
-                                                  er/try-expand-list
-                                                  '(org-mark-subtree
-                                                    er/mark-org-code-block
-                                                    er/mark-sentence
-                                                    er/mark-org-parent
-                                                    er/mark-paragraph))))
+  (set (make-local-variable 'er/try-expand-list)
+       (append
+        (remove #'er/mark-defun er/try-expand-list)
+        '(org-mark-subtree
+          er/mark-org-code-block
+          er/mark-sentence
+          er/mark-org-parent
+          er/mark-paragraph))))
 
 (er/enable-mode-expansions 'org-mode 'er/add-org-mode-expansions)
 


### PR DESCRIPTION
This pull request fixes:

* text-mode tests broken in #212 
* org-mode expansions broken in Emacs 24.4+
* c-mode expansion broken in Emacs 25.1

and ensures we test against Emacs 24.3 up to 25.1, plus trunk.