### PR TITLE
Deactivate mark when leaving expanded region in transient mark mode

### DIFF
--- a/expand-region-core.el
+++ b/expand-region-core.el
@@ -50,8 +50,7 @@
     (push-mark nil t)  ;; one for keeping starting position
     (push-mark nil t)) ;; one for replace by set-mark in expansions
 
-  (when (not (eq t transient-mark-mode))
-    (setq transient-mark-mode (cons 'only transient-mark-mode))))
+  (setq transient-mark-mode (cons 'only transient-mark-mode)))
 
 (defun er--copy-region-to-register ()
   (when (and (stringp expand-region-autocopy-register)


### PR DESCRIPTION
I believe this fixes magnars/expand-region.el#190. I can't say I fully understand all intricacies of transient mark mode, but the fix works for me at least.

I have verified the fix manually with and without transient-mark-mode in Emacs 24.5 and 25.1 and didn't notice any problems.