### PR TITLE
Assign a semantic score to expansions.

### DIFF
--- a/expand-region-core.el
+++ b/expand-region-core.el
@@ -123,18 +123,59 @@ moving point or mark as little as possible."
                (= best-end (point-max))) ;; We didn't find anything new, so exit early
       'early-exit)))
 
+(defun er--expansion-score (start end)
+  "Assign a score to the region between START and END inclusive.
+The bigger the score, the more semantic elements in the region.
+A better expansion should have a lower score."
+  (save-mark-and-excursion
+   (let ((word-chars 0)
+         (symbol-chars 0)
+         (punctuation-chars 0)
+         (space-chars 0)
+         (string-delim-chars 0)
+         (paren-chars 0)
+         (unbalanced-parens 0))
+     (goto-char start)
+     ;; For every character in the region, count the character classes.
+     (while (and (< (point) end) (not (eobp)))
+       (cl-case (char-syntax (following-char))
+         (?w (cl-incf word-chars))
+         (?_ (cl-incf symbol-chars))
+         (?. (cl-incf punctuation-chars))
+         (?\s (cl-incf space-chars))
+         (?\" (cl-incf string-delim-chars))
+         (?\( (cl-incf paren-chars) (cl-incf unbalanced-parens))
+         (?\) (cl-incf paren-chars) (cl-decf unbalanced-parens)))
+       (forward-char 1))
+     ;; Assign a score to the character classes, so
+     ;; "foobar" < "fo_bar"
+     ;; "fo_bar" < "fo.bar"
+     ;; and so on.
+     (+ word-chars
+        (* 10 symbol-chars)
+        (* 100 punctuation-chars)
+        (* 1000 space-chars)
+        (* 10000 string-delim-chars)
+        (* 100000 paren-chars)
+        ;; Heavily penalise unbalanced parens.
+        (* 1000000 (abs unbalanced-parens))))))
+
 (defun er--this-expansion-is-better (start end best-start best-end)
   "t if the current region is an improvement on previous expansions.
 
 This is provided as a separate function for those that would like
 to override the heuristic."
-  (and
-   (<= (point) start)
-   (>= (mark) end)
-   (> (- (mark) (point)) (- end start))
-   (or (> (point) best-start)
-       (and (= (point) best-start)
-            (< (mark) best-end)))))
+  (let ((new-start (point))
+        (new-end (mark)))
+    (and
+     ;; The current region must include, and be bigger than, START...END.
+     (<= new-start start)
+     (>= new-end end)
+     (> (- new-end new-start) (- end start))
+     ;; The current region is better than BEST-START...BEST-END if it
+     ;; includes fewer syntactic elements (it's a tighter expansion).
+     (< (er--expansion-score new-start new-end)
+        (er--expansion-score best-start best-end)))))
 
 (defun er/contract-region (arg)
   "Contract the selected region to its previous size.

--- a/expand-region-core.el
+++ b/expand-region-core.el
@@ -150,13 +150,14 @@ A better expansion should have a lower score."
      ;; Assign a score to the character classes, so
      ;; "foobar" < "fo_bar"
      ;; "fo_bar" < "fo.bar"
+     ;; "foobar()" < "fo = bar"
      ;; and so on.
      (+ word-chars
         (* 10 symbol-chars)
         (* 100 punctuation-chars)
-        (* 1000 space-chars)
-        (* 10000 string-delim-chars)
-        (* 100000 paren-chars)
+        (* 1000 paren-chars)
+        (* 10000 space-chars)
+        (* 100000 string-delim-chars)
         ;; Heavily penalise unbalanced parens.
         (* 1000000 (abs unbalanced-parens))))))
 

--- a/features/fgallina-python-el-expansions.feature
+++ b/features/fgallina-python-el-expansions.feature
@@ -34,6 +34,15 @@ Feature: fgallinas python.el expansions
     And I press "C-@"
     Then the region should be "foo_bar.baz"
 
+  Scenario: Mark function calls assigned to variables.
+    Given I turn on python-mode
+    And there is no region selected
+    When I insert "foo = bar()"
+    And I place the cursor after "bar"
+    And I press "C-@"
+    And I press "C-@"
+    Then the region should be "bar()"
+
   Scenario: Mark region inside a string with escape delimiter.
     Given I turn on python-mode
     And there is no region selected

--- a/features/fgallina-python-el-expansions.feature
+++ b/features/fgallina-python-el-expansions.feature
@@ -22,6 +22,18 @@ Feature: fgallinas python.el expansions
     And I press "C-@"
     Then the region should be "X-Men: Wolverine"
 
+  Scenario: Mark symbols and attributes.
+    Given I turn on python-mode
+    And there is no region selected
+    When I insert "foo_bar.baz = 1"
+    And I place the cursor after "bar"
+    And I press "C-@"
+    Then the region should be "bar"
+    And I press "C-@"
+    Then the region should be "foo_bar"
+    And I press "C-@"
+    Then the region should be "foo_bar.baz"
+
   Scenario: Mark region inside a string with escape delimiter.
     Given I turn on python-mode
     And there is no region selected
@@ -155,6 +167,7 @@ Feature: fgallinas python.el expansions
       def moo(data):
           for foo in data.items():
               print(foo)
+
       """
 
   Scenario: Mark an outer Python block


### PR DESCRIPTION
When choosing the best expansion, don't just choose the smallest
expansion that is bigger than the current region.

A pathological case before was `foo_|bar|.x` expanding to
`foo_|bar.x|` rather than `|foo_bar|.x`.

Instead, we calculate the number of different syntatic elements, and
choose the expansion with the smallest amount of additional syntax.

Fixes #210.