### PR TITLE
Reset transient mark mode to previous value when stopping expansion

### DIFF
--- a/expand-region-core.el
+++ b/expand-region-core.el
@@ -44,14 +44,21 @@
 (defvar er/try-expand-list nil
   "A list of functions that are tried when expanding.")
 
+(defvar er--transient-mark-mode-before-expanding nil
+  "The value of transient mark mode before expanding.")
+
 (defun er--prepare-expanding ()
+  (when (er--first-invocation)
+    (setq er--transient-mark-mode-before-expanding transient-mark-mode))
+
   (when (and (er--first-invocation)
              (not (use-region-p)))
     (push-mark nil t)  ;; one for keeping starting position
     (push-mark nil t)) ;; one for replace by set-mark in expansions
 
-  (when (or (not (eq t transient-mark-mode))
-            shift-select-mode)
+  (when (and (er--first-invocation)
+             (or (not (eq t transient-mark-mode))
+                 shift-select-mode))
     (setq transient-mark-mode (cons 'only transient-mark-mode))))
 
 (defun er--copy-region-to-register ()
@@ -148,7 +155,8 @@ before calling `er/expand-region' for the first time."
     (when er/history
       ;; Be sure to reset them all if called with 0
       (when (= arg 0)
-        (setq arg (length er/history)))
+        (setq arg (length er/history))
+        (setq transient-mark-mode er--transient-mark-mode-before-expanding))
 
       (when (not transient-mark-mode)
         (setq transient-mark-mode (cons 'only transient-mark-mode)))


### PR DESCRIPTION
This PR retains the value of `transient-mark-mode` before expanding, and resets `transient-mark-mode` to this value when stopping expansion.

When the value of `transient-mark-mode` contains 'only, the `exchange-point-and-mark` function will cons new 'only symbols to the `transient-mark-mode` value. When stopping expansion, this will leave the `transient-mark-mode` variable with several 'only symbols, causing the regular set-mark command (C-SPC) to be broken. When the value of `transient-mark-mode` is reset to the value before expanding, the set-mark command behaves correctly again.

This fixes #220 when `shift-select-mode` is active and when stopping the expansion with `C-g` or `0.`

When copying the region after expanding however (with `M-w` f.ex.), the value of `transient-mark-mode` is not reset and the regular set-mark command is broken again. I guess interfering in all these cases would lead too far, but this PR already fixes the basic case of stopping expansion with `C-g` or `0.`

@magnars Please feel tree to post your comments on this PR. I'm not a user of `shift-select-mode` myself, but since it seems to be enabled by default, I think it's important `expand-region` already handles the basic case.

Thanks!