### PR TITLE
transient-mark-mode 'only should be buffer-local

### DIFF
--- a/expand-region-core.el
+++ b/expand-region-core.el
@@ -50,7 +50,7 @@
     (push-mark nil t)  ;; one for keeping starting position
     (push-mark nil t)) ;; one for replace by set-mark in expansions
 
-  (when (not (eq t transient-mark-mode))
+  (when (not transient-mark-mode)
     (setq-local transient-mark-mode (cons 'only transient-mark-mode))))
 
 (defun er--copy-region-to-register ()

--- a/expand-region-core.el
+++ b/expand-region-core.el
@@ -51,7 +51,7 @@
     (push-mark nil t)) ;; one for replace by set-mark in expansions
 
   (when (not (eq t transient-mark-mode))
-    (setq transient-mark-mode (cons 'only transient-mark-mode))))
+    (setq-local transient-mark-mode (cons 'only transient-mark-mode))))
 
 (defun er--copy-region-to-register ()
   (when (and (stringp expand-region-autocopy-register)
@@ -150,7 +150,7 @@ before calling `er/expand-region' for the first time."
         (setq arg (length er/history)))
 
       (when (not transient-mark-mode)
-        (setq transient-mark-mode (cons 'only transient-mark-mode)))
+        (setq-local transient-mark-mode (cons 'only transient-mark-mode)))
 
       ;; Advance through the list the desired distance
       (while (and (cdr er/history)


### PR DESCRIPTION
Setting transient-mark-mode to the 'only construct was changed to buffer-local in the emacs code base back in 2014.  See https://github.com/emacs-mirror/emacs/commit/5d2638bd31586fc276ddd4444a49627e855cf7fa
Using expand-region causes problems in other buffers when this is set globally, because they will see the 'only value.