### PR TITLE
Include negative argument explicit shortcut in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ You can set it up like this:
     (require 'expand-region)
     (global-set-key (kbd "C-=") 'er/expand-region)
 
-If you expand too far, you can contract the region by pressing `-` (minus key).
+If you expand too far, you can contract the region by pressing `-` (minus key),
+or by prefixing the shortcut you defined with a negative argument: `C-- C-=`.
 
 ## Video
 


### PR DESCRIPTION
I ran across an issue where after pressing `C-=` multiple times in a row, the `-` option did not contract the region, and prefixing the command with a negative argument was needed.