### PR TITLE
Fix automatic loading of subword-mode expansions

### DIFF
--- a/expand-region-core.el
+++ b/expand-region-core.el
@@ -279,6 +279,14 @@ remove the keymap depends on user input and KEEP-PRED:
         (when (derived-mode-p mode)
           (funcall add-fn))))))
 
+(defun er/enable-minor-mode-expansions (mode add-fn)
+  (add-hook (intern (format "%s-hook" mode)) add-fn)
+  (save-window-excursion
+    (dolist (buffer (buffer-list))
+      (with-current-buffer buffer
+        (when (symbol-value mode)
+          (funcall add-fn))))))
+
 ;; Some more performant version of `looking-back'
 
 (defun er/looking-back-on-line (regexp)

--- a/expand-region.el
+++ b/expand-region.el
@@ -189,7 +189,7 @@ before calling `er/expand-region' for the first time."
 (eval-after-load 'cperl-mode     '(require 'cperl-mode-expansions))
 (eval-after-load 'sml-mode       '(require 'sml-mode-expansions))
 (eval-after-load 'enh-ruby-mode  '(require 'enh-ruby-mode-expansions))
-(eval-after-load 'subword-mode   '(require 'subword-mode-expansions))
+(eval-after-load 'subword        '(require 'subword-mode-expansions))
 
 (provide 'expand-region)
 

--- a/subword-mode-expansions.el
+++ b/subword-mode-expansions.el
@@ -42,9 +42,9 @@
   "Add expansions for buffers in `subword-mode'."
   (set (make-local-variable 'er/try-expand-list)
        (append er/try-expand-list
-	       '(er/mark-subword))))
+               '(er/mark-subword))))
 
-(er/enable-mode-expansions 'subword-mode 'er/add-subword-mode-expansions)
+(er/enable-minor-mode-expansions 'subword-mode 'er/add-subword-mode-expansions)
 
 (provide 'subword-mode-expansions)
 ;;; subword-mode-expansions.el ends here


### PR DESCRIPTION
The auto-loading of `subword-mode-expansions` was broken for a couple of reasons:

 - the `eval-after-load` hook wasn't firing, because `subword-mode` is defined in `subword.el`
 - the `derived-mode-p` check in `er/enable-mode-expansions` only works for major modes

This PR fixes both issues, and adds `er/enable-minor-mode-expansions` in case it's needed for anything else.