### PR TITLE
Alternative solution for org-mode unfolds

### DIFF
--- a/expand-region-core.el
+++ b/expand-region-core.el
@@ -44,6 +44,9 @@
 (defvar er/try-expand-list nil
   "A list of functions that are tried when expanding.")
 
+(defvar er/save-mode-excursion nil
+  "A function to save excursion state when expanding.")
+
 (defun er--prepare-expanding ()
   (when (and (er--first-invocation)
              (not (use-region-p)))
@@ -64,6 +67,13 @@
   (when (< emacs-major-version 25)
     (defmacro save-mark-and-excursion (&rest body)
       `(save-excursion ,@body))))
+
+(defmacro er--save-excursion (&rest body)
+  `(let ((action (lambda ()
+                   (save-mark-and-excursion ,@body))))
+     (if er/save-mode-excursion
+         (funcall er/save-mode-excursion action)
+       (funcall action))))
 
 (defun er--expand-region-1 ()
   "Increase selected region by semantic units.
@@ -96,7 +106,7 @@ moving point or mark as little as possible."
       (setq start (point)))
 
     (while try-list
-      (save-mark-and-excursion
+      (er--save-excursion
        (ignore-errors
          (funcall (car try-list))
          (when (and (region-active-p)

--- a/the-org-mode-expansions.el
+++ b/the-org-mode-expansions.el
@@ -32,6 +32,7 @@
 ;;; Code:
 
 (require 'expand-region-core)
+(require 'org-macs)
 
 (declare-function org-up-element "org")
 (declare-function org-mark-subtree "org")
@@ -71,6 +72,11 @@
   (org-up-element)
   (org-mark-subtree))
 
+(defun er/save-org-mode-excursion (action)
+  "Save outline visibility while expanding in org-mode"
+  (org-save-outline-visibility t
+    (funcall action)))
+
 (defun er/add-org-mode-expansions ()
   "Adds org-specific expansions for buffers in org-mode"
   (set (make-local-variable 'er/try-expand-list)
@@ -80,7 +86,9 @@
           er/mark-org-code-block
           er/mark-sentence
           er/mark-org-parent
-          er/mark-paragraph))))
+          er/mark-paragraph)))
+  (set (make-local-variable 'er/save-mode-excursion)
+       #'er/save-org-mode-excursion))
 
 (er/enable-mode-expansions 'org-mode 'er/add-org-mode-expansions)
 


### PR DESCRIPTION
Adds a new variable `er/save-mode-excursion` which will be used to wrap
expansion attempts if set.  In `org-mode` buffers this facility is used
to wrap actions with `org-save-outline-visibility`.