### PR TITLE
fix er/mark-comment

### DIFF
--- a/er-basic-expansions.el
+++ b/er-basic-expansions.el
@@ -101,14 +101,14 @@ period and marks next symbol."
   (interactive)
   (when (er--point-is-in-comment-p)
     (let ((p (point)))
-      (while (er--point-is-in-comment-p)
+      (while (and (er--point-is-in-comment-p) (not (eobp)))
         (forward-char 1))
-      (skip-chars-backward " \n\t\r")
+      (skip-chars-backward "\n\r")
       (set-mark (point))
       (goto-char p)
       (while (er--point-is-in-comment-p)
         (forward-char -1))
-      (skip-chars-forward " \n\t\r"))))
+      (forward-char 1))))
 
 ;; Quotes
 


### PR DESCRIPTION
- Don't call (forward-char 1) when point is at end of buffer.

- If there are trailing spaces and tabs in comment, include them.

- Don't include the non-whitespace char right before the comment
  prefix.

  In the following C function declaration, when the point is in the
  comment, calling er/mark-comment now selects the region between the
  two slashes (including the slashes).  Without this fix, the region
  would start at the '('.

    void func(/* int arg */);