### PR TITLE
Make usage message optional

### DIFF
--- a/expand-region-core.el
+++ b/expand-region-core.el
@@ -210,10 +210,10 @@ before calling `er/expand-region' for the first time."
              `(lambda ()
                 (interactive)
                 (setq this-command `,(cadr ',binding))
-                (or (minibufferp) (message "%s" ,msg))
+                (or (not expand-region-show-usage-message) (minibufferp) (message "%s" ,msg))
                 (eval `,(cdr ',binding))))))
        t)
-      (or (minibufferp) (message "%s" msg)))))
+      (or (not expand-region-show-usage-message) (minibufferp) (message "%s" msg)))))
 
 (if (fboundp 'set-temporary-overlay-map)
     (fset 'er/set-temporary-overlay-map 'set-temporary-overlay-map)

--- a/expand-region-custom.el
+++ b/expand-region-custom.el
@@ -115,6 +115,11 @@ If set to nil, always place the cursor at the beginning of the region."
   :type '(choice (const :tag "Enable subword expansions" t)
                  (const :tag "Disable subword expansions" nil)))
 
+(defcustom expand-region-show-usage-message t
+  "Whether expand-region should show usage message."
+  :group 'expand-region
+  :type 'boolean)
+
 (provide 'expand-region-custom)
 
 ;;; expand-region-custom.el ends here


### PR DESCRIPTION
For years of using this awesome package, hotkeys to expand region are in my muscle memory :) Just want to suppress the usage message because sometimes it's distracting.

Thanks!