### PR TITLE
Add html expansions to js-jsx mode

### DIFF
--- a/html-mode-expansions.el
+++ b/html-mode-expansions.el
@@ -97,6 +97,7 @@ around the equal sign or unquotes attributes atm."
 (er/enable-mode-expansions 'rhtml-mode 'er/add-html-mode-expansions)
 (er/enable-mode-expansions 'nxhtml-mode 'er/add-html-mode-expansions)
 (er/enable-mode-expansions 'web-mode 'er/add-html-mode-expansions)
+(er/enable-mode-expansions 'js-jsx-mode 'er/add-html-mode-expansions)
 
 (provide 'html-mode-expansions)
 


### PR DESCRIPTION
Hey there,

Very new to emacs here, so please let me know if there's another way to do that!
I'm trying to add the extra html expansions:

```
er/mark-html-attribute
er/mark-inner-tag
er/mark-outer-tag
```

to the js-jsx mode. I haven't found any way to do so without modifying the package's code. But maybe there is!