### PR TITLE
fix: load text-mode from symbol

### DIFF
--- a/expand-region.el
+++ b/expand-region.el
@@ -185,7 +185,7 @@ before calling `er/expand-region' for the first time."
 (eval-after-load 'ruby-mode      '(require 'ruby-mode-expansions))
 (eval-after-load 'org            '(require 'the-org-mode-expansions))
 (eval-after-load 'cc-mode        '(require 'cc-mode-expansions))
-(eval-after-load "text-mode"      '(require 'text-mode-expansions))
+(eval-after-load 'text-mode      '(require 'text-mode-expansions))
 (eval-after-load 'cperl-mode     '(require 'cperl-mode-expansions))
 (eval-after-load 'sml-mode       '(require 'sml-mode-expansions))
 (eval-after-load 'enh-ruby-mode  '(require 'enh-ruby-mode-expansions))


### PR DESCRIPTION
Related to 02a53cf.

When loading expand-region, I ran into issues where
`wrong-type-argument stringp (require . info)` popped up in my
backtraces buffer in Emacs 27.1:

    Debugger entered--Lisp error: (wrong-type-argument stringp (require . info))
      string-match("\\(\\`\\|/\\)text-mode\\(\\.elc\\|\\.el\\|\\.so\\)?\\(\\.gz\\)?\\..." (require . info))
      load-history-filename-element("\\(\\`\\|/\\)text-mode\\(\\.elc\\|\\.el\\|\\.so\\)?\\(\\.gz\\)?\\'")
      eval-after-load("text-mode" (lambda nil (require 'text-mode-expansions)))

Probing around, it turns out that text-mode was being loaded from a
string because the version that came with Emacs wasn't providing it as
a feature [until a few days later][1].

[1]: https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=f70f9a58c438d8b0677b1649ea7084d688ed53c8