### PR TITLE
Fix wrong type argument on Emacs 28.1

### DIFF
--- a/expand-region.el
+++ b/expand-region.el
@@ -185,7 +185,7 @@ before calling `er/expand-region' for the first time."
 (eval-after-load 'ruby-mode      '(require 'ruby-mode-expansions))
 (eval-after-load 'org            '(require 'the-org-mode-expansions))
 (eval-after-load 'cc-mode        '(require 'cc-mode-expansions))
-(eval-after-load "text-mode"      '(require 'text-mode-expansions))
+(eval-after-load 'text-mode      '(require 'text-mode-expansions))
 (eval-after-load 'cperl-mode     '(require 'cperl-mode-expansions))
 (eval-after-load 'sml-mode       '(require 'sml-mode-expansions))
 (eval-after-load 'enh-ruby-mode  '(require 'enh-ruby-mode-expansions))


### PR DESCRIPTION
After upgrading from Emacs 27 to 28.1, loading expand-region
breaks with the error message "Wrong type argument: stringp, (require .
package)"

This is due to using eval-after-load with a string argument. This odd
call style was introduced in

https://github.com/magnars/expand-region.el/pull/213

However, the assertion that text-mode is missing a provide call hasn't
been true in 6 years:

https://github.com/emacs-mirror/emacs/commit/f70f9a58c438d8b0677b1649ea7084d688ed53c8