### PR TITLE
TreesitER

### DIFF
--- a/expand-region.el
+++ b/expand-region.el
@@ -195,25 +195,7 @@ before calling `er/expand-region' for the first time."
 ;; Since treesit is behind a compile time flag (for now) we first check if it's available
 (when (and (functionp 'treesit-available-p)
            (treesit-available-p))
-  ;; treesit expansions can be loaded by any ts mode.
-  (eval-after-load 'c-ts-mode      '(require 'treesit-er-expansions))
-  (eval-after-load 'js-ts-mode     '(require 'treesit-er-expansions))
-  (eval-after-load 'go-ts-mode     '(require 'treesit-er-expansions))
-  (eval-after-load 'css-ts-mode    '(require 'treesit-er-expansions))
-  (eval-after-load 'c++-ts-mode    '(require 'treesit-er-expansions))
-  (eval-after-load 'html-ts-mode   '(require 'treesit-er-expansions))
-  (eval-after-load 'yaml-ts-mode   '(require 'treesit-er-expansions))
-  (eval-after-load 'bash-ts-mode   '(require 'treesit-er-expansions))
-  (eval-after-load 'ruby-ts-mode   '(require 'treesit-er-expansions))
-  (eval-after-load 'java-ts-mode   '(require 'treesit-er-expansions))
-  (eval-after-load 'toml-ts-mode   '(require 'treesit-er-expansions))
-  (eval-after-load 'json-ts-mode   '(require 'treesit-er-expansions))
-  (eval-after-load 'rust-ts-mode   '(require 'treesit-er-expansions))
-  (eval-after-load 'cmake-ts-mode  '(require 'treesit-er-expansions))
-  (eval-after-load 'csharp-ts-mode '(require 'treesit-er-expansions))
-  (eval-after-load 'python-ts-mode '(require 'treesit-er-expansions))
-  (eval-after-load 'go-mod-ts-mode '(require 'treesit-er-expansions))
-  (eval-after-load 'tsx-ts-mode    '(require 'treesit-er-expansions)))
+  (require 'treesit-er-expansions))
 
 (provide 'expand-region)
 

--- a/expand-region.el
+++ b/expand-region.el
@@ -192,6 +192,29 @@ before calling `er/expand-region' for the first time."
 (eval-after-load 'subword        '(require 'subword-mode-expansions))
 (eval-after-load 'yaml-mode      '(require 'yaml-mode-expansions))
 
+;; Since treesit is behind a compile time flag (for now) we first check if it's available
+(when (and (functionp 'treesit-available-p)
+           (treesit-available-p))
+  ;; treesit expansions can be loaded by any ts mode.
+  (eval-after-load 'c-ts-mode      '(require 'treesit-er-expansions))
+  (eval-after-load 'js-ts-mode     '(require 'treesit-er-expansions))
+  (eval-after-load 'go-ts-mode     '(require 'treesit-er-expansions))
+  (eval-after-load 'css-ts-mode    '(require 'treesit-er-expansions))
+  (eval-after-load 'c++-ts-mode    '(require 'treesit-er-expansions))
+  (eval-after-load 'html-ts-mode   '(require 'treesit-er-expansions))
+  (eval-after-load 'yaml-ts-mode   '(require 'treesit-er-expansions))
+  (eval-after-load 'bash-ts-mode   '(require 'treesit-er-expansions))
+  (eval-after-load 'ruby-ts-mode   '(require 'treesit-er-expansions))
+  (eval-after-load 'java-ts-mode   '(require 'treesit-er-expansions))
+  (eval-after-load 'toml-ts-mode   '(require 'treesit-er-expansions))
+  (eval-after-load 'json-ts-mode   '(require 'treesit-er-expansions))
+  (eval-after-load 'rust-ts-mode   '(require 'treesit-er-expansions))
+  (eval-after-load 'cmake-ts-mode  '(require 'treesit-er-expansions))
+  (eval-after-load 'csharp-ts-mode '(require 'treesit-er-expansions))
+  (eval-after-load 'python-ts-mode '(require 'treesit-er-expansions))
+  (eval-after-load 'go-mod-ts-mode '(require 'treesit-er-expansions))
+  (eval-after-load 'tsx-ts-mode    '(require 'treesit-er-expansions)))
+
 (provide 'expand-region)
 
 ;;; expand-region.el ends here

--- a/features/treesit-er-expansions.feature
+++ b/features/treesit-er-expansions.feature
@@ -1,0 +1,14 @@
+Feature: treesit expansions
+  Background:
+    Given there is no region selected
+    And I turn on rust-ts-mode
+
+    Scenario: Successively expand the region
+    When I insert "fn some_func(arg: String) -> String { arg.to_lowercase() }"
+    And I place the cursor before "to_lowercase"
+    And I press "C-@"
+    Then the region should be "to_lowercase"
+    And I press "C-@"
+    Then the region should be "arg.to_lowercase()"
+    And I press "C-@"
+    Then the region should be "{ arg.to_lowercase() }"

--- a/treesit-er-expansions.el
+++ b/treesit-er-expansions.el
@@ -50,27 +50,12 @@
 
 (defun er/add-treesit-er-expansion ()
   "Add the expansion for treesit mode."
-  (set (make-local-variable 'er/try-expand-list)
-       (append er/try-expand-list '(er/treesit-er-parent-node))))
+  (when (treesit-language-at (point))
+    (set (make-local-variable 'er/try-expand-list)
+         (append er/try-expand-list '(er/treesit-er-parent-node)))))
 
-(er/enable-mode-expansions 'c-ts-mode 'er/add-treesit-er-expansion)
-(er/enable-mode-expansions 'js-ts-mode 'er/add-treesit-er-expansion)
-(er/enable-mode-expansions 'go-ts-mode 'er/add-treesit-er-expansion)
-(er/enable-mode-expansions 'css-ts-mode 'er/add-treesit-er-expansion)
-(er/enable-mode-expansions 'c++-ts-mode 'er/add-treesit-er-expansion)
-(er/enable-mode-expansions 'html-ts-mode 'er/add-treesit-er-expansion)
-(er/enable-mode-expansions 'yaml-ts-mode 'er/add-treesit-er-expansion)
-(er/enable-mode-expansions 'bash-ts-mode 'er/add-treesit-er-expansion)
-(er/enable-mode-expansions 'ruby-ts-mode 'er/add-treesit-er-expansion)
-(er/enable-mode-expansions 'java-ts-mode 'er/add-treesit-er-expansion)
-(er/enable-mode-expansions 'toml-ts-mode 'er/add-treesit-er-expansion)
-(er/enable-mode-expansions 'json-ts-mode 'er/add-treesit-er-expansion)
-(er/enable-mode-expansions 'rust-ts-mode 'er/add-treesit-er-expansion)
-(er/enable-mode-expansions 'cmake-ts-mode 'er/add-treesit-er-expansion)
-(er/enable-mode-expansions 'csharp-ts-mode 'er/add-treesit-er-expansion)
-(er/enable-mode-expansions 'python-ts-mode 'er/add-treesit-er-expansion)
-(er/enable-mode-expansions 'go-mod-ts-mode 'er/add-treesit-er-expansion)
-(er/enable-mode-expansions 'tsx-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'prog-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'text-mode 'er/add-treesit-er-expansion)
 
 (provide 'treesit-er-expansions)
 

--- a/treesit-er-expansions.el
+++ b/treesit-er-expansions.el
@@ -51,8 +51,7 @@
 (defun er/add-treesit-er-expansion ()
   "Add the expansion for treesit mode."
   (set (make-local-variable 'er/try-expand-list)
-       ;; we don't need any other expansion rules once we have treesit
-       '(er/treesit-er-parent-node)))
+       (append er/try-expand-list '(er/treesit-er-parent-node))))
 
 (er/enable-mode-expansions 'c-ts-mode 'er/add-treesit-er-expansion)
 (er/enable-mode-expansions 'js-ts-mode 'er/add-treesit-er-expansion)

--- a/treesit-er-expansions.el
+++ b/treesit-er-expansions.el
@@ -1,0 +1,79 @@
+;;; treesit-er-expansions.el ---  -*- lexical-binding: t; -*-
+;; Copyright (C) 2023 Aleksandar Dimitrov
+
+
+;; Author: Aleksandar Dimitrov <git@aleks.bg>
+;; Created: 2023-03-13
+;; Keywords: marking region
+
+;; This file is not part of GNU Emacs.
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+
+;;; Code:
+
+(require 'treesit)
+(require 'expand-region-core)
+
+(defun er/treesit-er--get-node-between (a b)
+  "Find the node that sits above any node in the region (A B)."
+  (let* ((start (min a b))
+         (end (max a b)))
+    (treesit-parent-until
+     (treesit-node-at start)
+     (lambda (node) (< end (treesit-node-end node))))))
+
+(defun er/treesit-er-parent-node ()
+  "Expand to the node above point, or to the node above the active region."
+  (interactive)
+  (let ((node
+          (if (region-active-p)
+              (er/treesit-er--get-node-between (mark) (point))
+            (treesit-node-at (point)))))
+    (goto-char (treesit-node-start node))
+    (set-mark (treesit-node-end node))
+    (activate-mark)))
+
+(defun er/add-treesit-er-expansion ()
+  "Add the expansion for treesit mode."
+  (set (make-local-variable 'er/try-expand-list)
+       ;; we don't need any other expansion rules once we have treesit
+       '(er/treesit-er-parent-node)))
+
+(er/enable-mode-expansions 'c-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'js-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'go-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'css-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'c++-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'html-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'yaml-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'bash-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'ruby-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'java-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'toml-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'json-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'rust-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'cmake-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'csharp-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'python-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'go-mod-ts-mode 'er/add-treesit-er-expansion)
+(er/enable-mode-expansions 'tsx-ts-mode 'er/add-treesit-er-expansion)
+
+(provide 'treesit-er-expansions)
+
+;;; treesit-er-expansions.el ends here
+


### PR DESCRIPTION
Emacs 29 will bring `treesit`—a new way to incrementally parse files using `treesitter` grammars. It's fantastic :tada: 

This is supposed to bring treesit-based expansions to expand-region. Since we can use the AST directly, there is no need for more than one expansion rule, which makes the implementation almost trivial.

The only problem (and the reason this PR is still a draft) is that I can't figure out how to add the grammar files to the Emacs runtime used by ecukes. Any pointers are appreciated, but I'll try to tackle it over the weekend.

---

TODO:

- [x] Don't enumerate modes
- [x] Keep old expansions
- [ ] Fix over-eager treesitter expansions for treesitter nodes that are delimited by brackets
- [ ] Fix ecukes tests (probably a Cask configuration issue)