### PR TITLE
Performance improvements (for expensive excursions)

### DIFF
--- a/expand-region-core.el
+++ b/expand-region-core.el
@@ -72,8 +72,7 @@
       `(save-excursion ,@body))))
 
 (defmacro er--save-excursion (&rest body)
-  `(let ((action (lambda ()
-                   (save-mark-and-excursion ,@body))))
+  `(let ((action (lambda () ,@body)))
      (if er/save-mode-excursion
          (funcall er/save-mode-excursion action)
        (funcall action))))
@@ -109,17 +108,18 @@ moving point or mark as little as possible."
       (skip-chars-forward er--space-str)
       (setq start (point)))
 
-    (while try-list
-      (er--save-excursion
-       (ignore-errors
-         (funcall (car try-list))
-         (when (and (region-active-p)
-                    (er--this-expansion-is-better start end best-start best-end))
-           (setq best-start (point))
-           (setq best-end (mark))
-           (when (and er--show-expansion-message (not (minibufferp)))
-             (message "%S" (car try-list))))))
-      (setq try-list (cdr try-list)))
+    (er--save-excursion
+       (while try-list
+         (ignore-errors
+           (save-mark-and-excursion
+             (funcall (car try-list))
+             (when (and (region-active-p)
+                        (er--this-expansion-is-better start end best-start best-end))
+               (setq best-start (point))
+               (setq best-end (mark))
+               (when (and er--show-expansion-message (not (minibufferp)))
+                 (message "%S" (car try-list))))))
+         (setq try-list (cdr try-list))))
 
     (setq deactivate-mark nil)
     ;; if smart cursor enabled, decide to put it at start or end of region:

--- a/expand-region.el
+++ b/expand-region.el
@@ -157,6 +157,8 @@ before calling `er/expand-region' for the first time."
       (setq arg (- arg 1))
       (when (eq 'early-exit (er--expand-region-1))
         (setq arg 0)))
+    (when (er--first-invocation)
+      (setq-local er--saved-expansions nil))
     (when (and expand-region-fast-keys-enabled
                (not (memq last-command '(er/expand-region er/contract-region))))
       (er/prepare-for-more-expansions))))


### PR DESCRIPTION
These two commits improve the performance of expand-region.  This is most prominent when excursions are expensive, such as in Org mode, when `org-save-outline-visibility` is called repeatedly.

Commit 1: Reduce number of excursions/excursion cost
```
expand-region-core.el (er--expand-region-1, er--save-excursion): When
`er-save-excursion` is expensive, such as when using Org-mode's
`org-save-outline-visibility`, calling it repeatedly for each function
in `er/try-expand-list' is prohibitive. Fix by only calling it once
around the expansion trials, and using `save-mark-and-excursion`
around each expansion function.
```

Commit 2: Memoize when chaining expand-region calls.
```
expand-region-core.el (er--expand-region-1, er--saved-expansions): Use
a new buffer-local variable, `er--saved-expansions`, to hold
information about the point/mark returned by `er/try-expand-list'.  If
using `er/expand-region' or `er/contract-region' repeatedly, use this
memoized data instead of recomputing all expansions.  This speeds up
expand-region significantly when there are a large number of or
expensive functions in `er/try-expand-list'.

expand-region.el (er/expand-region): Clear the saved expansion data in
`er--saved-expansions` on the first (non-chained) invocation of
`er/expand-region' or `er-contract-region`
```.
