### PR TITLE
`expand-region-custom.el`: update docstrings to pass `checkdoc`

### DIFF
--- a/expand-region-custom.el
+++ b/expand-region-custom.el
@@ -31,14 +31,14 @@
 
 ;;;###autoload
 (defcustom expand-region-preferred-python-mode 'python
-  "The name of your preferred python mode"
+  "The name of your preferred python mode."
   :type '(choice (const :tag "Emacs' python.el" python)
                  (const :tag "fgallina's python.el" fgallina-python)
                  (const :tag "python-mode.el" python-mode)))
 
 ;;;###autoload
 (defcustom expand-region-guess-python-mode t
-  "If expand-region should attempt to guess your preferred python mode"
+  "If expand-region should attempt to guess your preferred python mode."
   :type '(choice (const :tag "Guess" t)
                  (const :tag "Do not guess" nil)))
 
@@ -51,20 +51,20 @@
 
 ;;;###autoload
 (defcustom expand-region-autocopy-register ""
-  "If set to a string of a single character (try \"e\"), then the
-contents of the most recent expand or contract command will
-always be copied to the register named after that character."
+  "Register to copy most recent expand or contract to.
+
+Activated when set to a string of a single character (for example, \"e\")."
   :type 'string)
 
 ;;;###autoload
 (defcustom expand-region-skip-whitespace t
-  "If expand-region should skip past whitespace on initial expansion"
+  "If expand-region should skip past whitespace on initial expansion."
   :type '(choice (const :tag "Skip whitespace" t)
                  (const :tag "Do not skip whitespace" nil)))
 
 ;;;###autoload
 (defcustom expand-region-fast-keys-enabled t
-  "If expand-region should bind fast keys after initial expand/contract"
+  "If expand-region should bind fast keys after initial expand/contract."
   :type '(choice (const :tag "Enable fast keys" t)
                  (const :tag "Disable fast keys" nil)))
 
@@ -81,7 +81,7 @@ always be copied to the register named after that character."
 ;;;###autoload
 (defcustom expand-region-exclude-text-mode-expansions
   '(html-mode nxml-mode)
-  "List of modes which derive from `text-mode' for which text mode expansions are not appropriate."
+  "List of modes derived from `text-mode' to exclude from text mode expansions."
   :type '(repeat (symbol :tag "Major Mode" unknown)))
 
 ;;;###autoload


### PR DESCRIPTION
Especially, fixes the following warning when `expand-region.el` is
installed:

```
package-quickstart.el:***:2: Warning: defvar
    `expand-region-exclude-text-mode-expansions' docstring wider than 80
    characters
```